### PR TITLE
feat: Add support for dynamic chunks

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -15615,14 +15615,15 @@ var src_generator = (undefined && undefined.__generator) || function (thisArg, b
 
 var ARTIFACT_NAME = 'next-bundle-analyzer';
 var FILE_NAME = 'bundle-sizes.json';
+var DYNAMIC_FILE_NAME = 'dynamic-bundle-sizes.json';
 function run() {
     var _a;
     return src_awaiter(this, void 0, void 0, function () {
-        var workflowId, baseBranch, octokit, issueNumber, masterBundleSizes, bundleSizes, dynamicBundleSizes, prefix, info, markdownTable, dynamicMarkdownTable, body, e_1;
+        var workflowId, baseBranch, octokit, issueNumber, masterBundleSizes, masterDynamicBundleSizes, bundleSizes, dynamicBundleSizes, prefix, info, markdownTable, dynamicBundleInfo, dynamicMarkdownTable, body, e_1;
         return src_generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
-                    _b.trys.push([0, 3, , 4]);
+                    _b.trys.push([0, 5, , 6]);
                     workflowId = core.getInput('workflow-id', { required: true });
                     baseBranch = core.getInput('base-branch') || 'master';
                     octokit = github.getOctokit(process.env.GITHUB_TOKEN || '');
@@ -15630,36 +15631,44 @@ function run() {
                     console.log("> Downloading bundle sizes from " + baseBranch);
                     return [4 /*yield*/, downloadArtifactAsJson(octokit, baseBranch, workflowId, ARTIFACT_NAME, FILE_NAME)];
                 case 1:
-                    masterBundleSizes = (_b.sent()) || { sha: 'none', data: { route: [], dynamicChunks: [] } };
+                    masterBundleSizes = (_b.sent()) || { sha: 'none', data: [] };
                     console.log(masterBundleSizes);
+                    return [4 /*yield*/, downloadArtifactAsJson(octokit, baseBranch, workflowId, ARTIFACT_NAME, DYNAMIC_FILE_NAME)];
+                case 2:
+                    masterDynamicBundleSizes = (_b.sent()) || { sha: 'none', data: [] };
+                    console.log(masterDynamicBundleSizes);
                     console.log('> Calculating local bundle sizes');
                     bundleSizes = getStaticBundleSizes();
                     console.log(bundleSizes);
                     dynamicBundleSizes = getDynamicBundleSizes();
                     console.log(dynamicBundleSizes);
                     console.log('> Uploading local bundle sizes');
-                    return [4 /*yield*/, uploadJsonAsArtifact(ARTIFACT_NAME, FILE_NAME, {
-                            route: bundleSizes,
-                            dynamicChunks: dynamicBundleSizes,
-                        })];
-                case 2:
+                    return [4 /*yield*/, uploadJsonAsArtifact(ARTIFACT_NAME, FILE_NAME, bundleSizes)];
+                case 3:
+                    _b.sent();
+                    return [4 /*yield*/, uploadJsonAsArtifact(ARTIFACT_NAME, DYNAMIC_FILE_NAME, dynamicBundleSizes)];
+                case 4:
                     _b.sent();
                     console.log('> Commenting on PR');
                     if (issueNumber) {
                         prefix = '### Bundle Sizes';
                         info = "Compared against " + masterBundleSizes.sha;
-                        markdownTable = getMarkdownTable(Array.isArray(masterBundleSizes.data) ? masterBundleSizes.data : masterBundleSizes.data.route, bundleSizes);
-                        dynamicMarkdownTable = getMarkdownTable(masterBundleSizes.data.dynamicChunks, dynamicBundleSizes, 'Dynamic chunks');
-                        body = prefix + "\n\n" + info + "\n\n" + markdownTable + "\n\n" + dynamicMarkdownTable;
+                        markdownTable = getMarkdownTable(masterBundleSizes.data, bundleSizes);
+                        dynamicBundleInfo = void 0;
+                        if (masterBundleSizes.sha !== masterDynamicBundleSizes.sha) {
+                            dynamicBundleInfo = "Compared against " + masterDynamicBundleSizes.sha;
+                        }
+                        dynamicMarkdownTable = getMarkdownTable(masterDynamicBundleSizes.data, dynamicBundleSizes, 'Dynamic chunks');
+                        body = prefix + "\n\n" + info + "\n\n" + markdownTable + "\n\n" + (dynamicBundleInfo ? dynamicBundleInfo + "\n\n" : '') + dynamicMarkdownTable;
                         createOrReplaceComment(octokit, issueNumber, prefix, body);
                     }
-                    return [3 /*break*/, 4];
-                case 3:
+                    return [3 /*break*/, 6];
+                case 5:
                     e_1 = _b.sent();
                     console.log(e_1);
                     core.setFailed(e_1.message);
-                    return [3 /*break*/, 4];
-                case 4: return [2 /*return*/];
+                    return [3 /*break*/, 6];
+                case 6: return [2 /*return*/];
             }
         });
     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -15236,24 +15236,15 @@ var external_zlib_default = /*#__PURE__*/__nccwpck_require__.n(external_zlib_);
 
 function getStaticBundleSizes() {
     var manifest = loadBuildManifest();
-    var pageSizes = Object.entries(manifest.pages).map(function (_a) {
-        var page = _a[0], files = _a[1];
-        var size = files
-            .map(function (filename) {
-            var fn = external_path_default().join(process.cwd(), '.next', filename);
-            var bytes = external_fs_default().readFileSync(fn);
-            var gzipped = external_zlib_default().gzipSync(bytes);
-            return gzipped.byteLength;
-        })
-            .reduce(function (s, b) { return s + b; }, 0);
-        return { page: page, size: size };
-    });
-    return pageSizes;
+    return getPageSizesFromManifest(manifest);
 }
 function getDynamicBundleSizes() {
     var staticManifest = loadBuildManifest();
     var manifest = loadReactLoadableManifest(staticManifest.pages['/_app']);
-    var pageSizes = Object.entries(manifest.pages).map(function (_a) {
+    return getPageSizesFromManifest(manifest);
+}
+function getPageSizesFromManifest(manifest) {
+    return Object.entries(manifest.pages).map(function (_a) {
         var page = _a[0], files = _a[1];
         var size = files
             .map(function (filename) {
@@ -15265,7 +15256,6 @@ function getDynamicBundleSizes() {
             .reduce(function (s, b) { return s + b; }, 0);
         return { page: page, size: size };
     });
-    return pageSizes;
 }
 function loadBuildManifest() {
     var file = external_fs_default().readFileSync(external_path_default().join(process.cwd(), '.next', 'build-manifest.json'), 'utf-8');

--- a/src/bundle-size.ts
+++ b/src/bundle-size.ts
@@ -13,27 +13,18 @@ export type PageBundleSizes = { page: string; size: number }[];
 export function getStaticBundleSizes(): PageBundleSizes {
   const manifest = loadBuildManifest();
 
-  const pageSizes: PageBundleSizes = Object.entries(manifest.pages).map(([page, files]) => {
-    const size = files
-      .map((filename: string) => {
-        const fn = path.join(process.cwd(), '.next', filename);
-        const bytes = fs.readFileSync(fn);
-        const gzipped = zlib.gzipSync(bytes);
-        return gzipped.byteLength;
-      })
-      .reduce((s: number, b: number) => s + b, 0);
-
-    return { page, size };
-  });
-
-  return pageSizes;
+  return getPageSizesFromManifest(manifest);
 }
 
 export function getDynamicBundleSizes(): PageBundleSizes {
   const staticManifest = loadBuildManifest();
   const manifest = loadReactLoadableManifest(staticManifest.pages['/_app']);
 
-  const pageSizes: PageBundleSizes = Object.entries(manifest.pages).map(([page, files]) => {
+  return getPageSizesFromManifest(manifest);
+}
+
+function getPageSizesFromManifest(manifest: BuildManifest): PageBundleSizes {
+  return Object.entries(manifest.pages).map(([page, files]) => {
     const size = files
       .map((filename: string) => {
         const fn = path.join(process.cwd(), '.next', filename);
@@ -45,8 +36,6 @@ export function getDynamicBundleSizes(): PageBundleSizes {
 
     return { page, size };
   });
-
-  return pageSizes;
 }
 
 function loadBuildManifest(): BuildManifest {

--- a/src/download-artifacts.ts
+++ b/src/download-artifacts.ts
@@ -10,7 +10,7 @@ export async function downloadArtifactAsJson(
   workflowId: string,
   artifactName: string,
   fileName: string
-): Promise<{ sha: string; data: { route: PageBundleSizes, dynamicChunks: PageBundleSizes } } | null> {
+): Promise<{ sha: string; data: PageBundleSizes } | null> {
   try {
     // Find latest workflow run on master
     console.log(

--- a/src/download-artifacts.ts
+++ b/src/download-artifacts.ts
@@ -10,7 +10,7 @@ export async function downloadArtifactAsJson(
   workflowId: string,
   artifactName: string,
   fileName: string
-): Promise<{ sha: string; data: PageBundleSizes } | null> {
+): Promise<{ sha: string; data: { route: PageBundleSizes, dynamicChunks: PageBundleSizes } } | null> {
   try {
     // Find latest workflow run on master
     console.log(


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->

If you use dynamic imports in your codebase then the data for those imports is stored in a different manifest file: `react-loadable-manifest.json`. This PR parses that manifest file and builds the second table that shows dynamic chunks data.

This new manifest file is a bit different from build-manifest so additional logic is needed to build the correct table. That is, each chunk has a list of files defined inside it, but its likely some of those are already imported statically via the `/_app` route in `build-manifest.json`. So we need to dedupe items that exists in build-manifest, build a unique list of leftover files and then pass it over to `getBundleSizes`.

Working examples:

- With dynamic chunks:
    - https://github.com/transferwise/homepage/pull/1109
    - https://github.com/transferwise/multi-currency-account-homepage/pull/811
    - https://github.com/transferwise/balance-flows-web/pull/817

- If no dynamic chunks, then works as expected: https://github.com/transferwise/web-onboarding/pull/567

- Data is now stored differently in the artifact but is backward compatible:
    - Test with new data structure: https://github.com/transferwise/homepage/runs/4119162415?check_suite_focus=true#step:10:18
    - Test with old data structure: https://github.com/transferwise/homepage/runs/4118919708?check_suite_focus=true#step:10:19

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
