### PR TITLE
Show only items that have changed significantly

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  printWidth: 100,
+  singleQuote: true,
+  trailingComma: 'all',
+};

--- a/dist/index.js
+++ b/dist/index.js
@@ -15261,7 +15261,7 @@ function getMarkdownTable(masterBundleSizes, bundleSizes) {
     if (significant.length > 0) {
         return formatTable(significant);
     }
-    return 'No files significant changes found.';
+    return 'No significant changes found.';
 }
 function getPageChangeInfo(masterBundleSizes, bundleSizes) {
     var addedAndChanged = bundleSizes.map(function (_a) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -15291,7 +15291,7 @@ function getPageChangeInfo(masterBundleSizes, bundleSizes) {
 function getSignificant(rows) {
     return rows.filter(function (_a) {
         var type = _a.type, diff = _a.diff;
-        return type !== 'changed' || diff > 100 || diff < 100;
+        return type !== 'changed' || diff > 100 || diff < -100;
     });
 }
 function formatTable(rows) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -15291,7 +15291,7 @@ function getPageChangeInfo(masterBundleSizes, bundleSizes) {
 function getSignificant(rows) {
     return rows.filter(function (_a) {
         var type = _a.type, diff = _a.diff;
-        return type !== 'changed' || diff > 100 || diff < -100;
+        return type !== 'changed' || diff >= 1000 || diff <= -1000;
     });
 }
 function formatTable(rows) {

--- a/src/bundle-size.ts
+++ b/src/bundle-size.ts
@@ -11,48 +11,94 @@ export type PageBundleSizes = { page: string; size: number }[];
 export function getBundleSizes(): PageBundleSizes {
   const manifest = loadManifest();
 
-  const pageSizes: PageBundleSizes = Object.entries(manifest.pages).map(([page, files]) => {
-    const size = files
-      .map((filename: string) => {
-        const fn = path.join(process.cwd(), '.next', filename);
-        const bytes = fs.readFileSync(fn);
-        const gzipped = zlib.gzipSync(bytes);
-        return gzipped.byteLength;
-      })
-      .reduce((s: number, b: number) => s + b, 0);
+  const pageSizes: PageBundleSizes = Object.entries(manifest.pages).map(
+    ([page, files]) => {
+      const size = files
+        .map((filename: string) => {
+          const fn = path.join(process.cwd(), '.next', filename);
+          const bytes = fs.readFileSync(fn);
+          const gzipped = zlib.gzipSync(bytes);
+          return gzipped.byteLength;
+        })
+        .reduce((s: number, b: number) => s + b, 0);
 
-    return { page, size };
-  });
+      return { page, size };
+    }
+  );
 
   return pageSizes;
 }
 
 function loadManifest(): BuildManifest {
-  const file = fs.readFileSync(path.join(process.cwd(), '.next', 'build-manifest.json'), 'utf-8');
+  const file = fs.readFileSync(
+    path.join(process.cwd(), '.next', 'build-manifest.json'),
+    'utf-8'
+  );
   return JSON.parse(file);
 }
 
 export function getMarkdownTable(
   masterBundleSizes: PageBundleSizes,
-  bundleSizes: PageBundleSizes,
+  bundleSizes: PageBundleSizes
 ): string {
   // Produce a Markdown table with each page, its size and difference to master
-  const sizes = bundleSizes
-    .map(({ page, size }) => {
+  const rows = getPageChangeInfo(masterBundleSizes, bundleSizes);
+  const significant = getSignificant(rows);
+
+  if (significant.length > 0) {
+    return formatTable(significant);
+  }
+  return 'No files significant changes found.';
+}
+
+type PageChangeInfo = {
+  page: string;
+  type: 'added' | 'changed' | 'removed';
+  size: number;
+  diff: number;
+};
+
+function getPageChangeInfo(
+  masterBundleSizes: PageBundleSizes,
+  bundleSizes: PageBundleSizes
+): PageChangeInfo[] {
+  const addedAndChanged: PageChangeInfo[] = bundleSizes.map(
+    ({ page, size }) => {
       const masterSize = masterBundleSizes.find((x) => x.page === page);
-      const diffStr = masterSize ? formatBytes(size - masterSize.size, true) : 'added';
-      return `| \`${page}\` | ${formatBytes(size)} | ${diffStr} |`;
-    })
-    .concat(
-      masterBundleSizes
-        .filter(({ page }) => !bundleSizes.find((x) => x.page === page))
-        .map(({ page }) => `| \`${page}\` | removed |`),
-    )
-    .join('\n');
+      if (masterSize) {
+        return {
+          page,
+          type: 'changed',
+          size,
+          diff: size - masterSize.size,
+        };
+      }
+      return { page, type: 'added', size, diff: size };
+    }
+  );
+
+  const removed: PageChangeInfo[] = masterBundleSizes
+    .filter(({ page }) => !bundleSizes.find((x) => x.page === page))
+    .map(({ page }) => ({ page, type: 'removed', size: 0, diff: 0 }));
+
+  return addedAndChanged.concat(removed);
+}
+
+function getSignificant(rows: PageChangeInfo[]): PageChangeInfo[] {
+  return rows.filter(
+    ({ type, diff }) => type !== 'changed' || diff > 100 || diff < 100
+  );
+}
+
+function formatTable(rows: PageChangeInfo[]): string {
+  const rowStrs = rows.map(({ page, type, size, diff }) => {
+    const diffStr = type === 'changed' ? formatBytes(diff, true) : type;
+    return `| \`${page}\` | ${formatBytes(size)} | ${diffStr} |`;
+  });
 
   return `| Route | Size (gzipped) | Diff |
   | --- | --- | --- |
-  ${sizes}`;
+  ${rowStrs.join('\n')}`;
 }
 
 function formatBytes(bytes: number, signed = false) {
@@ -67,7 +113,9 @@ function formatBytes(bytes: number, signed = false) {
 
   const i = Math.floor(Math.log(Math.abs(bytes)) / Math.log(k));
 
-  return `${sign}${parseFloat(Math.abs(bytes / k ** i).toFixed(dm))} ${sizes[i]}`;
+  return `${sign}${parseFloat(Math.abs(bytes / k ** i).toFixed(dm))} ${
+    sizes[i]
+  }`;
 }
 
 function getSign(bytes: number) {

--- a/src/bundle-size.ts
+++ b/src/bundle-size.ts
@@ -11,35 +11,30 @@ export type PageBundleSizes = { page: string; size: number }[];
 export function getBundleSizes(): PageBundleSizes {
   const manifest = loadManifest();
 
-  const pageSizes: PageBundleSizes = Object.entries(manifest.pages).map(
-    ([page, files]) => {
-      const size = files
-        .map((filename: string) => {
-          const fn = path.join(process.cwd(), '.next', filename);
-          const bytes = fs.readFileSync(fn);
-          const gzipped = zlib.gzipSync(bytes);
-          return gzipped.byteLength;
-        })
-        .reduce((s: number, b: number) => s + b, 0);
+  const pageSizes: PageBundleSizes = Object.entries(manifest.pages).map(([page, files]) => {
+    const size = files
+      .map((filename: string) => {
+        const fn = path.join(process.cwd(), '.next', filename);
+        const bytes = fs.readFileSync(fn);
+        const gzipped = zlib.gzipSync(bytes);
+        return gzipped.byteLength;
+      })
+      .reduce((s: number, b: number) => s + b, 0);
 
-      return { page, size };
-    }
-  );
+    return { page, size };
+  });
 
   return pageSizes;
 }
 
 function loadManifest(): BuildManifest {
-  const file = fs.readFileSync(
-    path.join(process.cwd(), '.next', 'build-manifest.json'),
-    'utf-8'
-  );
+  const file = fs.readFileSync(path.join(process.cwd(), '.next', 'build-manifest.json'), 'utf-8');
   return JSON.parse(file);
 }
 
 export function getMarkdownTable(
   masterBundleSizes: PageBundleSizes,
-  bundleSizes: PageBundleSizes
+  bundleSizes: PageBundleSizes,
 ): string {
   // Produce a Markdown table with each page, its size and difference to master
   const rows = getPageChangeInfo(masterBundleSizes, bundleSizes);
@@ -60,22 +55,20 @@ type PageChangeInfo = {
 
 function getPageChangeInfo(
   masterBundleSizes: PageBundleSizes,
-  bundleSizes: PageBundleSizes
+  bundleSizes: PageBundleSizes,
 ): PageChangeInfo[] {
-  const addedAndChanged: PageChangeInfo[] = bundleSizes.map(
-    ({ page, size }) => {
-      const masterSize = masterBundleSizes.find((x) => x.page === page);
-      if (masterSize) {
-        return {
-          page,
-          type: 'changed',
-          size,
-          diff: size - masterSize.size,
-        };
-      }
-      return { page, type: 'added', size, diff: size };
+  const addedAndChanged: PageChangeInfo[] = bundleSizes.map(({ page, size }) => {
+    const masterSize = masterBundleSizes.find((x) => x.page === page);
+    if (masterSize) {
+      return {
+        page,
+        type: 'changed',
+        size,
+        diff: size - masterSize.size,
+      };
     }
-  );
+    return { page, type: 'added', size, diff: size };
+  });
 
   const removed: PageChangeInfo[] = masterBundleSizes
     .filter(({ page }) => !bundleSizes.find((x) => x.page === page))
@@ -85,9 +78,7 @@ function getPageChangeInfo(
 }
 
 function getSignificant(rows: PageChangeInfo[]): PageChangeInfo[] {
-  return rows.filter(
-    ({ type, diff }) => type !== 'changed' || diff >= 1000 || diff <= -1000
-  );
+  return rows.filter(({ type, diff }) => type !== 'changed' || diff >= 1000 || diff <= -1000);
 }
 
 function formatTable(rows: PageChangeInfo[]): string {
@@ -113,9 +104,7 @@ function formatBytes(bytes: number, signed = false) {
 
   const i = Math.floor(Math.log(Math.abs(bytes)) / Math.log(k));
 
-  return `${sign}${parseFloat(Math.abs(bytes / k ** i).toFixed(dm))} ${
-    sizes[i]
-  }`;
+  return `${sign}${parseFloat(Math.abs(bytes / k ** i).toFixed(dm))} ${sizes[i]}`;
 }
 
 function getSign(bytes: number) {

--- a/src/bundle-size.ts
+++ b/src/bundle-size.ts
@@ -86,7 +86,7 @@ function getPageChangeInfo(
 
 function getSignificant(rows: PageChangeInfo[]): PageChangeInfo[] {
   return rows.filter(
-    ({ type, diff }) => type !== 'changed' || diff > 100 || diff < -100
+    ({ type, diff }) => type !== 'changed' || diff >= 1000 || diff <= -1000
   );
 }
 

--- a/src/bundle-size.ts
+++ b/src/bundle-size.ts
@@ -48,7 +48,7 @@ export function getMarkdownTable(
   if (significant.length > 0) {
     return formatTable(significant);
   }
-  return 'No files significant changes found.';
+  return 'No significant changes found.';
 }
 
 type PageChangeInfo = {

--- a/src/bundle-size.ts
+++ b/src/bundle-size.ts
@@ -86,7 +86,7 @@ function getPageChangeInfo(
 
 function getSignificant(rows: PageChangeInfo[]): PageChangeInfo[] {
   return rows.filter(
-    ({ type, diff }) => type !== 'changed' || diff > 100 || diff < 100
+    ({ type, diff }) => type !== 'changed' || diff > 100 || diff < -100
   );
 }
 


### PR DESCRIPTION
## Context

If an app has a lot of routes, the table is very very long. Instead, only print a row for routes that have changed by over a KB.

Example: https://github.com/transferwise/balance-flows-web/pull/871#issuecomment-980075721
(See comment history for version without dynamic imports)

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
