### PR TITLE
Add explicit github-token input

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,8 @@ Add the following step to a workflow which runs on a [pull_request](https://docs
   with:
     # Optional, specifies where to look for .next folder. Default to cwd.
     working-directory: ./apps/my-next-app
-  env:
-    # This secret is automatically injected by GitHub
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # Optional, defaults to `github.token`.
+    github-token: ${{ github.token }}
 ```
 
 ### On a Pull Request

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,14 @@
 name: 'Next.js bundle analyzer'
-inputs:
-  working-directory:
-    description: 'Directory containing built files'
-    default: ''
+description: 'Measure Next.js app page sizes and notify of changes in PR comments'
 runs:
   using: 'node20'
   main: 'dist/index.js'
+inputs:
+  working-directory:
+    description: 'Directory containing built files'
+    required: false
+    default: ''
+  github-token:
+    description: 'The GitHub token used to authenticate with the GitHub API.'
+    required: false
+    default: ${{ github.token }}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,11 +15,12 @@ const COMMENT_TITLE = '## Bundle Sizes';
 
 async function run() {
   try {
-    const workingDir = core.getInput('working-directory') || '';
+    const workingDir = core.getInput('working-directory');
+    const token = core.getInput('github-token');
     const appName = determineAppName(workingDir);
     const artifactName = `${ARTIFACT_NAME_PREFIX}${appName}`;
 
-    const octokit = getOctokit(process.env.GITHUB_TOKEN || '');
+    const octokit = getOctokit(token);
 
     const {
       data: { default_branch },


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->

Adds explicit github-token input for the action, so it is no longer necessary to pass it through environment variables. It also defaults to `${{ github.token }}` so you most likely don't need to specify it.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
