### PR TITLE
Fix artifact ordering being the wrong way around

### DIFF
--- a/src/download-artifacts.ts
+++ b/src/download-artifacts.ts
@@ -23,7 +23,7 @@ async function findArtifactForBranch({
     .sort((a, b) => {
       const aDate = new Date(a.created_at ?? 0);
       const bDate = new Date(b.created_at ?? 0);
-      return aDate.getTime() - bDate.getTime();
+      return bDate.getTime() - aDate.getTime();
     });
   return matchingArtifact ?? null;
 }


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->

We were fetching older reference artifacts rather than newer ones for bundle size comparison.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
