### PR TITLE
Paginate artifact finding, bump TS target to ES2017

### DIFF
--- a/src/download-artifacts.ts
+++ b/src/download-artifacts.ts
@@ -27,7 +27,7 @@ async function findArtifactForBranch({
   let pageIndex = 0;
   for await (const { data: artifacts } of artifactPageIterator) {
     for (const artifact of artifacts) {
-      if (artifact.workflow_run?.head_branch === branch) {
+      if (artifact.workflow_run?.head_branch === branch && !artifact.expired) {
         return artifact;
       }
     }

--- a/src/download-artifacts.ts
+++ b/src/download-artifacts.ts
@@ -4,6 +4,9 @@ import { context } from '@actions/github';
 import { Octokit } from './types';
 import { PageBundleSizes } from './bundle-size';
 
+const TOTAL_PAGES_LIMIT = 10;
+const ARTIFACTS_PER_PAGE_LIMIT = 100;
+
 async function findArtifactForBranch({
   octokit,
   branch,
@@ -13,19 +16,27 @@ async function findArtifactForBranch({
   branch: string;
   artifactName: string;
 }) {
-  // TODO: Paginate
-  const { data } = await octokit.rest.actions.listArtifactsForRepo({
-    ...context.repo,
-    name: artifactName,
-  });
-  const [matchingArtifact] = data.artifacts
-    .filter((artifact) => artifact.workflow_run?.head_branch === branch)
-    .sort((a, b) => {
-      const aDate = new Date(a.created_at ?? 0);
-      const bDate = new Date(b.created_at ?? 0);
-      return bDate.getTime() - aDate.getTime();
-    });
-  return matchingArtifact ?? null;
+  const artifactPageIterator = octokit.paginate.iterator(
+    octokit.rest.actions.listArtifactsForRepo,
+    {
+      ...context.repo,
+      name: artifactName,
+      per_page: ARTIFACTS_PER_PAGE_LIMIT,
+    },
+  );
+  let pageIndex = 0;
+  for await (const { data: artifacts } of artifactPageIterator) {
+    for (const artifact of artifacts) {
+      if (artifact.workflow_run?.head_branch === branch) {
+        return artifact;
+      }
+    }
+    if (pageIndex++ >= TOTAL_PAGES_LIMIT) {
+      console.log(`Artifact not found in last ${TOTAL_PAGES_LIMIT} pages`);
+      break;
+    }
+  }
+  return null;
 }
 
 export async function downloadArtifactAsJson(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,9 +7,8 @@
     // Project options
     "allowJs": true,
     "isolatedModules": true,
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "jsx": "preserve",
-    "target": "es5",
+    "lib": ["esnext"],
+    "target": "ES2017",
     "module": "esnext",
     "moduleResolution": "node",
     "noEmit": true,


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->

Turns out Octokit has a convenient [pagination API](https://github.com/octokit/octokit.js/?tab=readme-ov-file#pagination).
I also bumped TS target to ES2017 because it seemed wasteful and not very useful to generate polyfills for async/iterator code.

Could there also be an alternative approach of saving the workflow id into the reference bundle sizes issue and fetching that later instead of iterating through workflow run history?

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
