### PR TITLE
Add flag to disable issue creation v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ Add the following step to a workflow which runs on a [pull_request](https://docs
     #   always: Always comment on PRs, even if it's just to say there are no significant changes.
     #   skip-insignificant: Skip commenting on PRs if there are no signficant changes in page sizes.
     comment-strategy: 'always'
-    # Optional, set to no to not create the bundle size summary issue. Defaults to yes.
-    create-issue: yes
+    # Optional, configures whether to create the bundle size summary issue, defaults to `true`.
+    # Available options:
+    #   true
+    #   false
+    create-issue: true
     # Optional, defaults to `github.token`.
     github-token: ${{ github.token }}
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Add the following step to a workflow which runs on a [pull_request](https://docs
     #   always: Always comment on PRs, even if it's just to say there are no significant changes.
     #   skip-insignificant: Skip commenting on PRs if there are no signficant changes in page sizes.
     comment-strategy: 'always'
+    # Optional, set to no to not create the bundle size summary issue. Defaults to yes.
+    create-issue: yes
     # Optional, defaults to `github.token`.
     github-token: ${{ github.token }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -18,8 +18,13 @@ inputs:
     required: false
     default: 'always'
   create-issue:
-    description: 'Whether or not to create the bundle size issue'
-    default: 'yes'
+    description: >
+      Configures whether to create the bundle size summary issue.
+
+      Available options:
+        true
+        false
+    default: 'true'
   github-token:
     description: 'The GitHub token used to authenticate with the GitHub API.'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
         skip-insignificant: Skip commenting on PRs if there are no signficant changes in page sizes.
     required: false
     default: 'always'
+  create-issue:
+    description: 'Whether or not to create the bundle size issue'
+    default: 'yes'
   github-token:
     description: 'The GitHub token used to authenticate with the GitHub API.'
     required: false

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ async function run() {
         routesTable,
         strategy: inputs.commentStrategy,
       });
-    } else if (context.ref === `refs/heads/${default_branch}`) {
+    } else if (context.ref === `refs/heads/${default_branch}` && inputs.createIssue) {
       console.log('> Creating/updating bundle size issue');
       const title = `Bundle sizes [${appName}]`;
       const routesTable = getSingleColumnMarkdownTable({ bundleSizes, name: 'Route' });

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -16,7 +16,7 @@ export function getInputs(): ActionInputs {
   const inputs = {
     workingDirectory,
     commentStrategy: commentStrategy === 'skip-insignificant' ? 'skip-insignificant' : 'always',
-    createIssue: createIssue !== 'no' && createIssue !== 'false',
+    createIssue: createIssue !== 'false',
     githubToken,
   } satisfies ActionInputs;
 

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -3,17 +3,20 @@ import * as core from '@actions/core';
 export interface ActionInputs {
   workingDirectory: string;
   commentStrategy: 'always' | 'skip-insignificant';
+  createIssue: boolean;
   githubToken: string;
 }
 
 export function getInputs(): ActionInputs {
   const workingDirectory = core.getInput('working-directory');
   const commentStrategy = core.getInput('comment-strategy');
+  const createIssue = core.getInput('create-issue');
   const githubToken = core.getInput('github-token');
 
   const inputs = {
     workingDirectory,
     commentStrategy: commentStrategy === 'skip-insignificant' ? 'skip-insignificant' : 'always',
+    createIssue: createIssue !== 'no' && createIssue !== 'false',
     githubToken,
   } satisfies ActionInputs;
 


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->

Our organization's repo does not have issues enabled, so the issue creation step of this workflow fails. This PR adds a `create-issue` flag that can be set to `no` to skip creating/updating the bundle size issue.

Supersedes #40 

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
