### PR TITLE
Fix node version not being recognised in workflow parameters

### DIFF
--- a/.github/actions/bootstrap/action.yaml
+++ b/.github/actions/bootstrap/action.yaml
@@ -14,7 +14,7 @@ runs:
     - name: Setup node
       uses: actions/setup-node@v4
       with:
-        node-version-file: .nvmrc
+        node-version-file: '.nvmrc'
 
     - name: Install dependencies
       run: pnpm install --unsafe-perm --ignore-scripts


### PR DESCRIPTION
## Context

I noticed that we're still getting warnings from GHA when we run this analyzer - I looked at the [docs](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file) and I think `.nvmrc` needs to be wrapped in quotes.

![Screenshot 2024-07-09 at 16 31 05](https://github.com/transferwise/actions-next-bundle-analyzer/assets/19511562/7f3f3002-a01e-4ec1-883c-c784d7125058)

## Checklist
- [X] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
